### PR TITLE
Fixed an error when importing importing structure files into Sapien

### DIFF
--- a/io_scene_halo/file_gr2/export_sidecar_xml.py
+++ b/io_scene_halo/file_gr2/export_sidecar_xml.py
@@ -561,9 +561,9 @@ def WriteScenarioContents(metadata, asset_path, asset_name):
                         cookie_perm.append(perm)
 
             for perm in structure_perm:
-                network = ET.SubElement(object, 'ContentNetwork' ,Name=asset_name + '_' + "{0:03}".format(bsp) + perm + '_' + 'bsp', Type="")
-                ET.SubElement(network, 'InputFile').text = GetInputFilePathBSP(asset_path, asset_name, "{0:03}".format(bsp), 'bsp', perm)
-                ET.SubElement(network, 'IntermediateFile').text = GetIntermediateFilePathBSP(asset_path, asset_name, "{0:03}".format(bsp), 'bsp', perm)
+                network = ET.SubElement(object, 'ContentNetwork' ,Name=asset_name + '_' + "{0:03}".format(bsp) + perm + '_' + 'structure', Type="")
+                ET.SubElement(network, 'InputFile').text = GetInputFilePathBSP(asset_path, asset_name, "{0:03}".format(bsp), 'structure', perm)
+                ET.SubElement(network, 'IntermediateFile').text = GetIntermediateFilePathBSP(asset_path, asset_name, "{0:03}".format(bsp), 'structure', perm)
             for perm in poop_perm:
                 network = ET.SubElement(object, 'ContentNetwork' ,Name=asset_name + '_' + "{0:03}".format(bsp) + '_' + perm + '_' + 'poops', Type="")
                 ET.SubElement(network, 'InputFile').text = GetInputFilePathBSP(asset_path, asset_name,  "{0:03}".format(bsp), 'poops', perm)


### PR DESCRIPTION
The error was "(granny file data\levels\tutorial\export\models\test_000_bsp.gr2) failed to import granny file: file 'data\levels\tutorial\export\models\test_000_bsp.gr2' not found"