### PR TITLE
Instance Proxy CoACD

### DIFF
--- a/blender/addons/io_scene_foundry/blender_manifest.toml
+++ b/blender/addons/io_scene_foundry/blender_manifest.toml
@@ -26,7 +26,8 @@ wheels = [
   "./wheels/pythonnet-3.0.5-py3-none-any.whl",
   "./wheels/networkx-3.4.2-py3-none-any.whl",
   "./wheels/pillow-12.2.0-cp313-cp313-win_amd64.whl",
-  "./wheels/py360convert-1.0.4-py3-none-any.whl"
+  "./wheels/py360convert-1.0.4-py3-none-any.whl",
+  "./wheels/coacd-1.0.11-cp39-abi3-win_amd64.whl"
 ]
 
 [build]

--- a/blender/addons/io_scene_foundry/build_extension.py
+++ b/blender/addons/io_scene_foundry/build_extension.py
@@ -31,6 +31,7 @@ REQUIRED_WHEELS: tuple[tuple[str, str], ...] = (
     ("networkx", "3.4.2"),
     ("pillow", "12.2.0"),
     ("py360convert", "1.0.4"),
+    ("coacd", "1.0.11"),
 )
 
 

--- a/blender/addons/io_scene_foundry/props/scene.py
+++ b/blender/addons/io_scene_foundry/props/scene.py
@@ -2896,6 +2896,99 @@ class NWO_ScenePropertiesGroup(PropertyGroup):
     
     # user_removed_all_zone_set: bpy.props.BoolProperty()
 
+    coacd_threshold: bpy.props.FloatProperty(
+        name="Concavity Threshold",
+        description="Controls how tightly the hulls hug the original mesh",
+        default=0.05,
+        min=0.01,
+        max=1.0,
+    )
+    coacd_max_hulls: bpy.props.IntProperty(
+        name="Max Hulls",
+        description="Sets the absolute limit on the number of generated convex shapes (-1 for no limit)",
+        default=5,
+        min=-1,
+        max=64,
+    )
+    coacd_preprocess_mode: bpy.props.EnumProperty(
+        name="Preprocess",
+        description="Controls manifold preprocessing mode. Set to 'Off' for open or unclosed meshes",
+        items=[
+            ("auto", "Auto", "Automatically checks and preprocesses non-manifold meshes"),
+            ("on", "On", "Forces preprocessing on (for non-watertight/dirty meshes)"),
+            ("off", "Off", "Forces preprocessing off (retains original open mesh structure)"),
+        ],
+        default="auto",
+    )
+    coacd_decimate: bpy.props.BoolProperty(
+        name="Decimate Hulls",
+        description="Enable vertex decimation on generated convex hulls",
+        default=True,
+    )
+    coacd_max_vertices: bpy.props.IntProperty(
+        name="Max Vertices per Hull",
+        description="Maximum number of vertices allowed for each convex hull",
+        default=32,
+        min=4,
+        max=1024,
+    )
+    coacd_preprocess_resolution: bpy.props.IntProperty(
+        name="Preprocess Resolution",
+        description="Resolution for manifold preprocessing (20-100)",
+        default=50,
+        min=20,
+        max=100,
+    )
+    coacd_sample_resolution: bpy.props.IntProperty(
+        name="Sample Resolution",
+        description="Sampling resolution for Hausdorff distance calculation (1000-10000)",
+        default=2000,
+        min=1000,
+        max=10000,
+    )
+    coacd_mcts_nodes: bpy.props.IntProperty(
+        name="MCTS Nodes",
+        description="Max number of child nodes in MCTS (10-40)",
+        default=20,
+        min=10,
+        max=40,
+    )
+    coacd_mcts_iterations: bpy.props.IntProperty(
+        name="MCTS Iterations",
+        description="Number of search iterations in MCTS (60-2000)",
+        default=150,
+        min=60,
+        max=2000,
+    )
+    coacd_mcts_max_depth: bpy.props.IntProperty(
+        name="MCTS Max Depth",
+        description="Max search depth in MCTS (1-7)",
+        default=3,
+        min=1,
+        max=7,
+    )
+    coacd_pca: bpy.props.BoolProperty(
+        name="PCA",
+        description="Enable PCA pre-processing",
+        default=False,
+    )
+    coacd_merge: bpy.props.BoolProperty(
+        name="Merge",
+        description="Enable merge post-processing",
+        default=True,
+    )
+    coacd_seed: bpy.props.IntProperty(
+        name="Seed",
+        description="Random seed used for sampling (0 for random)",
+        default=0,
+        min=0,
+    )
+    coacd_advanced: bpy.props.BoolProperty(
+        name="Advanced Settings",
+        description="Show advanced CoACD parameters",
+        default=False,
+    )
+
     def items_mesh_type(self, context):
         """Function to handle context for mesh enum lists"""
         h4 = utils.is_corinth(context)

--- a/blender/addons/io_scene_foundry/tools/__init__.py
+++ b/blender/addons/io_scene_foundry/tools/__init__.py
@@ -60,7 +60,7 @@ from .barebones_model_format import NWO_OT_ExportBMF
 is_blender_startup = True
 
 # import Tool Operators
-from .instance_proxies import NWO_ProxyInstanceNew, NWO_ProxyInstanceCancel, NWO_ProxyInstanceEdit, NWO_ProxyInstanceDelete
+from .instance_proxies import NWO_ProxyInstanceNew, NWO_ProxyInstanceCancel, NWO_ProxyInstanceEdit, NWO_ProxyInstanceDelete, NWO_GenerateCoacdPhysics
 
 #######################################
 # NEW TOOL UI
@@ -127,6 +127,7 @@ classes = (
     NWO_ProxyInstanceDelete,
     NWO_ProxyInstanceEdit,
     NWO_ProxyInstanceNew,
+    NWO_GenerateCoacdPhysics,
     NWO_CollectionManager_CreateMove,
     NWO_CollectionManager_Create,
     NWO_AutoSeam,

--- a/blender/addons/io_scene_foundry/tools/instance_proxies.py
+++ b/blender/addons/io_scene_foundry/tools/instance_proxies.py
@@ -169,13 +169,30 @@ class NWO_ProxyInstanceNew(bpy.types.Operator):
         items=proxy_type_items,
     )
 
-    proxy_source : bpy.props.EnumProperty(
-        name="Source",
-        items=[
+    def proxy_source_items(self, context):
+        import os
+        from ..utils import get_prefs
+        
+        items = [
             ("bounding_box", "Bounding Box", "Generates a bounding box based on this instance"),
             ("copy", "Copy", "Copies this instance and removes any render only faces"),
             ("existing", "Mesh", "Creates a proxy using the specified scene mesh object"),
         ]
+        
+        proxy_type = getattr(self, "proxy_type", "")
+        if proxy_type == "":
+            pt_items = self.proxy_type_items(context)
+            if pt_items:
+                proxy_type = pt_items[0][0]
+                
+        if proxy_type == "physics":
+            items.append(("coacd", "CoACD", "Generates optimized game-ready convex hulls using CoACD"))
+            
+        return items
+
+    proxy_source : bpy.props.EnumProperty(
+        name="Source",
+        items=proxy_source_items,
     )
 
     proxy_copy : bpy.props.StringProperty(
@@ -270,6 +287,13 @@ class NWO_ProxyInstanceNew(bpy.types.Operator):
         proxy_type = self.proxy_type
         if proxy_type == "":
             proxy_type = self.proxy_type_items(context)[0][0]
+            
+        if self.proxy_source == "coacd":
+            if proxy_type != "physics":
+                self.report({'WARNING'}, "CoACD only generates Physics proxies.")
+                return {'CANCELLED'}
+            return bpy.ops.nwo.generate_coacd_physics()
+
         # self.scene_coll = context.scene.collection.objects
         self.proxy_name = f"{self.parent.name}_proxy_{proxy_type}"
         if self.proxy_source == "bounding_box":
@@ -327,8 +351,44 @@ class NWO_ProxyInstanceNew(bpy.types.Operator):
         if self.proxy_source == "existing":
             row = layout.row()
             row.prop_search(self, "proxy_copy", search_data=bpy.data, search_property="meshes")
-        row = layout.row()
-        row.prop(self, "proxy_edit", text="Edit Proxy")
+        elif self.proxy_source == "coacd":
+            scene = context.scene
+            
+            layout.prop(scene.nwo, "coacd_threshold")
+            layout.prop(scene.nwo, "coacd_max_hulls")
+            
+            layout.prop(scene.nwo, "coacd_decimate")
+            if scene.nwo.coacd_decimate:
+                layout.prop(scene.nwo, "coacd_max_vertices")
+            
+            layout.separator()
+            
+            adv_box = layout.box()
+            row_header = adv_box.row(align=True)
+            row_header.alignment = 'LEFT'
+            row_header.prop(
+                scene.nwo,
+                "coacd_advanced",
+                text="Advanced Settings",
+                icon="TRIA_DOWN" if scene.nwo.coacd_advanced else "TRIA_RIGHT",
+                emboss=False,
+            )
+            
+            if scene.nwo.coacd_advanced:
+                adv_box.prop(scene.nwo, "coacd_preprocess_mode")
+                if scene.nwo.coacd_preprocess_mode != 'off':
+                    adv_box.prop(scene.nwo, "coacd_preprocess_resolution")
+                adv_box.prop(scene.nwo, "coacd_sample_resolution")
+                adv_box.prop(scene.nwo, "coacd_mcts_nodes")
+                adv_box.prop(scene.nwo, "coacd_mcts_iterations")
+                adv_box.prop(scene.nwo, "coacd_mcts_max_depth")
+                adv_box.prop(scene.nwo, "coacd_pca")
+                adv_box.prop(scene.nwo, "coacd_merge")
+                adv_box.prop(scene.nwo, "coacd_seed")
+                
+        if self.proxy_source != "coacd":
+            row = layout.row()
+            row.prop(self, "proxy_edit", text="Edit Proxy")
     
 class NWO_ProxyInstanceDelete(bpy.types.Operator):
     bl_idname = "nwo.proxy_instance_delete"
@@ -379,3 +439,163 @@ class NWO_ProxyInstanceCancel(bpy.types.Operator):
     def execute(self, context):
         get_scene_props().instance_proxy_running = False
         return {'FINISHED'}
+
+class NWO_GenerateCoacdPhysics(bpy.types.Operator):
+    bl_idname = "nwo.generate_coacd_physics"
+    bl_label = "Generate Havok Hulls"
+    bl_description = "Generates optimized game-ready convex hulls using CoACD"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object is not None and context.active_object.type == 'MESH'
+
+    def execute(self, context):
+        import os
+        import bmesh
+        import numpy as np
+
+        try:
+            import coacd
+        except ImportError:
+            self.report({'ERROR'}, "CoACD module not found. Please rebuild the extension with build_extension.py")
+            return {'CANCELLED'}
+
+        active_ob = context.active_object
+        if not active_ob or active_ob.type != 'MESH':
+            self.report({'ERROR'}, "No active mesh object selected.")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        original_selected = context.selected_objects.copy()
+
+        try:
+            # Extract mesh data for CoACD
+            depsgraph = context.evaluated_depsgraph_get()
+            eval_ob = active_ob.evaluated_get(depsgraph)
+            mesh = eval_ob.to_mesh()
+            
+            # Triangulate mesh using bmesh
+            bm = bmesh.new()
+            bm.from_mesh(mesh)
+            bmesh.ops.triangulate(bm, faces=bm.faces[:])
+            bm.to_mesh(mesh)
+            bm.free()
+
+            # Convert to numpy arrays
+            vertices = np.empty((len(mesh.vertices), 3), dtype=np.float32)
+            mesh.vertices.foreach_get('co', vertices.ravel())
+            
+            faces = np.empty((len(mesh.polygons), 3), dtype=np.int32)
+            mesh.polygons.foreach_get('vertices', faces.ravel())
+            
+            eval_ob.to_mesh_clear()
+
+            # Run CoACD
+            coacd_mesh = coacd.Mesh(vertices, faces)
+            
+            kwargs = {
+                "threshold": scene.nwo.coacd_threshold,
+                "max_convex_hull": scene.nwo.coacd_max_hulls,
+                "preprocess_mode": scene.nwo.coacd_preprocess_mode,
+                "preprocess_resolution": scene.nwo.coacd_preprocess_resolution,
+                "resolution": scene.nwo.coacd_sample_resolution,
+                "mcts_nodes": scene.nwo.coacd_mcts_nodes,
+                "mcts_iterations": scene.nwo.coacd_mcts_iterations,
+                "mcts_max_depth": scene.nwo.coacd_mcts_max_depth,
+                "pca": scene.nwo.coacd_pca,
+                "merge": scene.nwo.coacd_merge,
+                "seed": scene.nwo.coacd_seed,
+            }
+            
+            if scene.nwo.coacd_decimate:
+                kwargs["max_ch_vertex"] = scene.nwo.coacd_max_vertices
+                kwargs["decimate"] = True
+                
+            parts = coacd.run_coacd(coacd_mesh, **kwargs)
+
+            if not parts:
+                self.report({'ERROR'}, "CoACD generated no mesh hulls.")
+                return {'CANCELLED'}
+            
+            original_name = active_ob.name
+            armature_parent = active_ob.parent
+
+            # Restore active object context for proxy_instance_new
+            context.view_layer.objects.active = active_ob
+
+            original_objects_set = set(bpy.data.objects.keys())
+            
+            imported_hulls = []
+            for idx, (p_verts, p_faces) in enumerate(parts):
+                # Create a new mesh in blender
+                me = bpy.data.meshes.new(f"coacd_hull_{idx}")
+                
+                # CoACD returns numpy arrays, convert to flat list for from_pydata
+                me.from_pydata(p_verts.tolist(), [], p_faces.tolist())
+                me.update()
+                
+                hull_ob = bpy.data.objects.new(me.name, me)
+                context.collection.objects.link(hull_ob)
+                
+                # Assign to imported hulls
+                imported_hulls.append(hull_ob)
+                
+                # Set world matrix before running proxy_instance_new
+                hull_ob.matrix_world = active_ob.matrix_world
+
+                # Call proxy_instance_new to create a proxy physics mesh from the local-space hull data
+                bpy.ops.nwo.proxy_instance_new(
+                    proxy_type="physics",
+                    proxy_source="existing",
+                    proxy_copy=hull_ob.data.name,
+                    proxy_edit=False
+                )
+                
+                # Find the newly created object in the database
+                new_objects = [bpy.data.objects[name] for name in bpy.data.objects.keys() if name not in original_objects_set]
+                if new_objects:
+                    proxy_ob = new_objects[0]
+                    original_objects_set.add(proxy_ob.name)
+                    
+                    # Rename proxy object using standard HEK physics prefixes
+                    proxy_ob.name = f"$physics_hull_{original_name}_{idx:02d}"
+                    
+                    # Ensure mesh type is set to physics
+                    proxy_ob.data.nwo.mesh_type = '_connected_geometry_mesh_type_physics'
+                    
+                    # Set the proxy's world transform to match the active object's world transform
+                    proxy_ob.matrix_world = active_ob.matrix_world.copy()
+                    
+                    # Parent if necessary
+                    if armature_parent and armature_parent.type == 'ARMATURE':
+                        matrix_world = proxy_ob.matrix_world.copy()
+                        proxy_ob.parent = armature_parent
+                        proxy_ob.matrix_world = matrix_world
+
+            # Delete the imported hulls and their mesh data to avoid cluttering the scene
+            for hull in imported_hulls:
+                hull_mesh = hull.data
+                bpy.data.objects.remove(hull, do_unlink=True)
+                bpy.data.meshes.remove(hull_mesh)
+
+            self.report({'INFO'}, f"Successfully generated {len(imported_hulls)} Havok hulls.")
+
+        except Exception as e:
+            self.report({'ERROR'}, f"Error during CoACD physics generation: {str(e)}")
+            return {'CANCELLED'}
+
+        finally:
+
+            for ob in original_selected:
+                try:
+                    ob.select_set(True)
+                except:
+                    pass
+            try:
+                context.view_layer.objects.active = active_ob
+            except:
+                pass
+
+        return {'FINISHED'}
+


### PR DESCRIPTION
Added Approximate Convex Decomposition for 3D Meshes with Collision-Aware Concavity and Tree Search (CoACD) for in the proxy creation button for instance geometry. This is useful for automating physics model creation in larger batches.

It might be good to further extend things later and allow it to be used for objects other than instances. Also a batch tool within the tools tab to generate for all instances in the scene.

You can read more about how CoACD works here: https://github.com/SarahWeiii/CoACD